### PR TITLE
feat(core): add RequiredX type

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ npm i @utype/core
 
 <a href="./docs/types/mutable-x.md" target="_blank" ><img src="https://img.shields.io/badge/MutableX-f31260" alt="MutableX" /></a>
 <a href="./docs/types/partial-x.md" target="_blank" ><img src="https://img.shields.io/badge/PartialX-f31260" alt="PartialX" /></a>
+<a href="./docs/types/required-x.md" target="_blank" ><img src="https://img.shields.io/badge/RequiredX-f31260" alt="RequiredX" /></a>
 <a href="./docs/types/readonly-x.md" target="_blank" ><img src="https://img.shields.io/badge/ReadonlyX-f31260" alt="ReadonlyX" /></a>
 <a href="./docs/types/deep-readonly-x.md" target="_blank" ><img src="https://img.shields.io/badge/DeepReadonlyX-f31260" alt="DeepReadonlyX" /></a>
 

--- a/docs/.vitepress/pages/types.json
+++ b/docs/.vitepress/pages/types.json
@@ -31,6 +31,10 @@
         "text": "PartialX"
       },
       {
+        "link": "/required-x",
+        "text": "RequiredX"
+      },
+      {
         "link": "/deep-readonly-x",
         "text": "DeepReadonlyX"
       },

--- a/docs/types/required-x.md
+++ b/docs/types/required-x.md
@@ -1,0 +1,27 @@
+---
+category: X Series
+alias: RequiredByKeys
+---
+
+# PartialX
+
+<TypeInfo category="X Series" :alias="['RequiredByKeys']" />
+
+Constructs a type by setting the properties specified by `K`(string literal or union of string literals) to required from `T`.
+
+## Usage
+
+```ts
+import type { RequiredX } from '@utype/core'
+
+type Prop = {
+  name?: string;
+  age?: number;
+  visible?: boolean;
+}
+
+// Expect: { name: string; age: number; visible?: boolean; } // [!code highlight]
+type RequiredXProp = RequiredX<Prop, 'name' | 'age'>
+// @ts-expect-error
+type Error = RequiredX<Prop, "sports"> // [!code error]
+```

--- a/packages/core/RequiredX/index.d.test.ts
+++ b/packages/core/RequiredX/index.d.test.ts
@@ -1,0 +1,38 @@
+import type { RequiredX } from "@utype/core";
+import { Equal, Expect } from "@utype/shared";
+
+type BaseCase = {
+  name?: string;
+  age?: number;
+  address?: string;
+};
+
+type RequiredXCase1 = {
+  name: string;
+  age?: number;
+  address?: string;
+};
+
+type RequiredXCase2 = {
+  name: string;
+  age: number;
+  address?: string;
+};
+
+type RequiredXCase3 = {
+  name: string;
+  age: number;
+  address: string;
+};
+
+type cases = [
+  Expect<Equal<RequiredX<BaseCase, "name">, RequiredXCase1>>,
+  Expect<Equal<RequiredX<BaseCase, "name" | "age">, RequiredXCase2>>,
+  Expect<Equal<RequiredX<BaseCase>, RequiredXCase3>>,
+  Expect<Equal<RequiredX<BaseCase>, Required<BaseCase>>>
+];
+
+type errors = [
+  // @ts-expect-error
+  RequiredX<BaseCase, "sports">
+];

--- a/packages/core/RequiredX/index.d.ts
+++ b/packages/core/RequiredX/index.d.ts
@@ -1,0 +1,26 @@
+import { Duplicate } from "@utype/shared";
+
+/**
+ * RequiredX
+ * @description Constructs a type by setting the properties specified by `K`(string literal or union of string literals) to required from `T`.
+ * @alias RequiredByKeys
+ * @example
+ *  type Prop = {
+ *    name?: string;
+ *    age?: number;
+ *    visible?: boolean;
+ *  }
+ *  // Expect: { name: string; age: number; visible?: boolean; }
+ *  type RequiredXProp = RequiredX<Prop, 'name' | 'age'>
+ */
+export type RequiredX<T, K extends keyof T = keyof T> = Duplicate<
+  Required<Pick<T, K>> & Omit<T, K>
+>;
+
+// alias
+
+/**
+ * RequiredByKeys
+ * @description Alias for RequiredX
+ */
+export type RequiredByKeys<T, K extends keyof T = keyof T> = RequiredX<T, K>;

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -6,6 +6,7 @@ export * from './DeepPartial'
 export * from './MutableX'
 export * from './ReadonlyX'
 export * from './PartialX'
+export * from './RequiredX'
 export * from './DeepReadonlyX'
 
 export * from './Merge'


### PR DESCRIPTION
Add new Type: RequiredX, alias is RequiredByKeys.

It will constructs a type by setting the properties specified by K(string literal or union of string literals) to requiredfrom T.

Example:

```ts
type Prop = {
   name?: string;
   age?: number;
   visible?: boolean;
}
// Expect: { name: string; age: number; visible?: boolean; }
type RequiredXProp = RequiredX<Prop, 'name' | 'age'>
```
