### PR TITLE
feat(core): add PickByRequired type

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ npm i @utype/core
 <a href="./docs/types/omit-by-type.md" target="_blank" ><img src="https://img.shields.io/badge/OmitByType-f31260" alt="OmitByType" /></a>
 <a href="./docs/types/omit-by-type-fuzzy.md" target="_blank" ><img src="https://img.shields.io/badge/OmitByTypeFuzzy-f31260" alt="OmitByTypeFuzzy" /></a>
 <a href="./docs/types/omit-by-type-exact.md" target="_blank" ><img src="https://img.shields.io/badge/OmitByTypeExact-f31260" alt="OmitByTypeExact" /></a>
+<a href="./docs/types/pick-by-required.md" target="_blank" ><img src="https://img.shields.io/badge/PickByRequired-f31260" alt="PickByRequired" /></a>
 
 ### 🚀 String Operation
 

--- a/docs/.vitepress/pages/types.json
+++ b/docs/.vitepress/pages/types.json
@@ -135,6 +135,10 @@
         "text": "OmitByTypeExact"
       },
       {
+        "link": "/pick-by-required",
+        "text": "PickByRequired"
+      },
+      {
         "link": "/kebab-case",
         "text": "KebabCase"
       },

--- a/docs/types/pick-by-required.md
+++ b/docs/types/pick-by-required.md
@@ -1,0 +1,24 @@
+---
+category: Generate Object
+alias: GetRequired
+---
+
+# PickByRequired
+
+<TypeInfo category="Generate Object" :alias="['GetRequired']" />
+
+From T pick all required properties to generate a new object type.
+
+## Usage
+
+```ts
+import type { PickByRequired } from '@utype/core'
+
+type Prop = {
+  foo: number;
+  bar?: string;
+}
+
+// Expect: { foo: number; } // [!code highlight]
+type PickByRequiredProp = PickByRequired<Prop>
+```

--- a/packages/core/PickByRequired/index.d.test.ts
+++ b/packages/core/PickByRequired/index.d.test.ts
@@ -1,0 +1,27 @@
+import type { PickByRequired } from "@utype/core";
+import { Equal, Expect } from "@utype/shared";
+
+type Case1 = {
+  foo: number;
+  bar?: string;
+};
+type PickByTypeCase1 = { foo: number };
+
+type Case2 = {
+  foo: undefined;
+  bar?: undefined;
+};
+type PickByTypeCase2 = { foo: undefined; };
+
+type Case3 = {
+  foo?: number;
+  bar?: number | undefined;
+  faz?: boolean;
+};
+type PickByTypeCase3 = {};
+
+type cases = [
+  Expect<Equal<PickByRequired<Case1>, PickByTypeCase1>>,
+  Expect<Equal<PickByRequired<Case2>, PickByTypeCase2>>,
+  Expect<Equal<PickByRequired<Case3>, PickByTypeCase3>>
+];

--- a/packages/core/PickByRequired/index.d.ts
+++ b/packages/core/PickByRequired/index.d.ts
@@ -1,0 +1,23 @@
+import { RequiredKeys } from "@utype/core";
+
+/**
+ * PickByRequired
+ * @description From T pick all required properties to generate a new object type.
+ * @alias GetRequired
+ * @example
+ *  type Prop = {
+ *      foo: number;
+ *      bar?: string;
+ *  }
+ *  // Expect: { foo: number; }
+ *  type PickByRequiredProp = PickByRequired<Prop>
+ */
+export type PickByRequired<T extends object> = Pick<T, RequiredKeys<T>>;
+
+// alias
+
+/**
+ * GetRequired
+ * @description Alias for PickByRequired
+ */
+export type GetRequired<T extends object> = PickByRequired<T>;

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -32,6 +32,7 @@ export * from './PickByTypeExact'
 export * from './OmitByType'
 export * from './OmitByTypeFuzzy'
 export * from './OmitByTypeExact'
+export * from './PickByRequired'
 
 export * from './KebabCase'
 export * from './SnakeCase'


### PR DESCRIPTION
Add new Type: PickByRequired, alias is GetRequired.

It will from T pick all required properties to generate a new object type.

Example:

```ts
type Prop = {
  foo: number;
  bar?: string;
}
// Expect: { foo: number; }
type PickByRequiredProp = PickByRequired<Prop>
```