### PR TITLE
feat(core): add DeepRequired type

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ npm i @utype/core
 <a href="./docs/types/deep-mutable.md" target="_blank" ><img src="https://img.shields.io/badge/DeepMutable-006FEE" alt="DeepMutable" /></a>
 <a href="./docs/types/deep-readonly.md" target="_blank" ><img src="https://img.shields.io/badge/DeepReadonly-006FEE" alt="DeepReadonly" /></a>
 <a href="./docs/types/deep-partial.md" target="_blank" ><img src="https://img.shields.io/badge/DeepPartial-006FEE" alt="DeepPartial" /></a>
+<a href="./docs/types/deep-required.md" target="_blank" ><img src="https://img.shields.io/badge/DeepRequired-006FEE" alt="DeepRequired" /></a>
 
 ### 🚀 X Series
 

--- a/docs/.vitepress/pages/types.json
+++ b/docs/.vitepress/pages/types.json
@@ -19,6 +19,10 @@
         "text": "DeepPartial"
       },
       {
+        "link": "/deep-required",
+        "text": "DeepRequired"
+      },
+      {
         "link": "/mutable-x",
         "text": "MutableX"
       },

--- a/docs/types/deep-required.md
+++ b/docs/types/deep-required.md
@@ -1,0 +1,32 @@
+---
+category: Object Operation
+---
+
+# DeepRequired
+
+<TypeInfo category="Object Operation" />
+
+Make every parameter of an object - and its sub-objects recursively - required.
+
+## Usage
+
+```ts{11-17}
+import type { DeepRequired } from '@utype/core'
+
+type Prop = {
+  x: {
+    a?: 1
+    b: 'hi'
+  },
+  y?: 'hey'
+}
+
+// Expect: {
+//   x: {
+//     a: 1,
+//     b: 'hi'
+//   }
+//   y: 'hey'
+// }
+type DeepRequiredProp = DeepRequired<Prop>
+```

--- a/packages/core/DeepRequired/index.d.test.ts
+++ b/packages/core/DeepRequired/index.d.test.ts
@@ -1,0 +1,57 @@
+import type { DeepRequired } from "@utype/core";
+import { Equal, Expect } from "@utype/shared";
+
+type Case1 = {
+  a: () => 22;
+  b?: string;
+  c?: {
+    d: boolean;
+    e?: {
+      g: {
+        h?: {
+          i: true;
+          j?: "string";
+        };
+        k?: "hello";
+      };
+      l?: [
+        "hi",
+        {
+          m: ["hey"];
+        }
+      ];
+    };
+  };
+};
+type DeepRequiredCase1 = {
+  a: () => 22;
+  b: string;
+  c: {
+    d: boolean;
+    e: {
+      g: {
+        h: {
+          i: true;
+          j: "string";
+        };
+        k: "hello";
+      };
+      l: [
+        "hi",
+        {
+          m: ["hey"];
+        }
+      ];
+    };
+  };
+};
+
+type TT = DeepRequired<Case1>
+
+type Case2 = { a?: string } | { b?: number };
+type DeepRequiredCase2 = { a: string } | { b: number };
+
+type cases = [
+  Expect<Equal<DeepRequired<Case1>, DeepRequiredCase1>>,
+  Expect<Equal<DeepRequired<Case2>, DeepRequiredCase2>>
+];

--- a/packages/core/DeepRequired/index.d.ts
+++ b/packages/core/DeepRequired/index.d.ts
@@ -1,0 +1,36 @@
+import { Keys, OnlyObject } from "@utype/shared";
+import { NonUndefined } from "@utype/core";
+
+/**
+ * DeepRequired
+ * @description Make every parameter of an object - and its sub-objects recursively - required.
+ * @example
+ *  type Prop = {
+ *    x: {
+ *      a?: 1
+ *      b: 'hi'
+ *    },
+ *    y?: 'hey'
+ *  }
+ *  // Expect: {
+ *  //   x: {
+ *  //     a: 1,
+ *  //     b: 'hi'
+ *  //   }
+ *  //   y: 'hey'
+ *  // }
+ * type DeepRequiredProp = DeepRequired<Prop>
+ */
+// todo need support array
+export type DeepRequired<T> = T extends OnlyObject
+  ? _DeepRequiredObject<T>
+  : T;
+
+/** @private */
+export interface _DeepRequiredArray<T>
+  extends Array<DeepRequired<NonUndefined<T>>> {}
+
+/** @private */
+export type _DeepRequiredObject<T> = {
+  [P in Keys<T>]-?: DeepRequired<NonUndefined<T[P]>>;
+};

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -2,6 +2,7 @@ export * from './Mutable'
 export * from './DeepMutable'
 export * from './DeepReadonly'
 export * from './DeepPartial'
+export * from './DeepRequired'
 
 export * from './MutableX'
 export * from './ReadonlyX'


### PR DESCRIPTION
Add new Type: DeepRequired.

It will make every parameter of an object - and its sub-objects recursively - required.

Example:

```ts
type Prop = {
  x: {
    a?: 1
    b: 'hi'
  },
  y?: 'hey'
}

// Expect: {
//   x: {
//     a: 1,
//     b: 'hi'
//   }
//   y: 'hey'
// }
type DeepRequiredProp = DeepRequired<Prop>
```