### PR TITLE
feat(core): add Intersection type

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ npm i @utype/core
 <a href="./docs/types/omit-by-type.md" target="_blank" ><img src="https://img.shields.io/badge/OmitByType-f31260" alt="OmitByType" /></a>
 <a href="./docs/types/omit-by-type-fuzzy.md" target="_blank" ><img src="https://img.shields.io/badge/OmitByTypeFuzzy-f31260" alt="OmitByTypeFuzzy" /></a>
 <a href="./docs/types/omit-by-type-exact.md" target="_blank" ><img src="https://img.shields.io/badge/OmitByTypeExact-f31260" alt="OmitByTypeExact" /></a>
+<a href="./docs/types/intersection.md" target="_blank" ><img src="https://img.shields.io/badge/Intersection-f31260" alt="Intersection" /></a>
 
 ### 🚀 String Operation
 

--- a/docs/.vitepress/pages/types.json
+++ b/docs/.vitepress/pages/types.json
@@ -139,6 +139,10 @@
         "text": "OmitByTypeExact"
       },
       {
+        "link": "/intersection",
+        "text": "Intersection"
+      },
+      {
         "link": "/kebab-case",
         "text": "KebabCase"
       },

--- a/docs/types/intersection.md
+++ b/docs/types/intersection.md
@@ -1,0 +1,21 @@
+---
+category: Generate Object
+---
+
+# Intersection
+
+<TypeInfo category="Generate Object" />
+
+From T pick properties that exist in U.
+
+## Usage
+
+```ts
+import type { Intersection } from '@utype/core'
+
+type Prop = { name: string; age: number; visible: boolean }
+type DefaultProps = { age: number; sex: string }
+
+// Expect: { age: number; } // [!code highlight]
+type IntersectionProp = Intersection<Prop, DefaultProps>
+```

--- a/packages/core/Intersection/index.d.test.ts
+++ b/packages/core/Intersection/index.d.test.ts
@@ -1,0 +1,17 @@
+import type { Intersection } from "@utype/core";
+import { Equal, Expect } from "@utype/shared";
+
+type Case = {
+  name: string;
+  age: number;
+  visible: boolean;
+};
+type DefaultCase = {
+  age: number;
+  sex: string;
+};
+type IntersectionCase = {
+  age: number;
+};
+
+type cases = [Expect<Equal<Intersection<Case, DefaultCase>, IntersectionCase>>];

--- a/packages/core/Intersection/index.d.ts
+++ b/packages/core/Intersection/index.d.ts
@@ -1,0 +1,12 @@
+import { Keys } from "@utype/shared";
+
+/**
+ * Intersection
+ * @description From T pick properties that exist in U.
+ * @example
+ *  type Prop = { name: string; age: number; visible: boolean }
+ *  type DefaultProps = { age: number; sex: string }
+ *  // Expect: { age: number; }
+ *  type IntersectionProp = Intersection<Prop, DefaultProps>
+ */
+export type Intersection<T, U> = Pick<T, Extract<Keys<T>, Keys<U>>>;

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -33,6 +33,7 @@ export * from './PickByTypeExact'
 export * from './OmitByType'
 export * from './OmitByTypeFuzzy'
 export * from './OmitByTypeExact'
+export * from './Intersection'
 
 export * from './KebabCase'
 export * from './SnakeCase'


### PR DESCRIPTION
Add new Type: Intersection<T, U>.

It will from T pick properties that exist in U.

Example:

```ts
type Prop = { name: string; age: number; visible: boolean }
type DefaultProps = { age: number; sex: string }

// Expect: { age: number; } // [!code highlight]
type IntersectionProp = Intersection<Prop, DefaultProps>
```
