### PR TITLE
feat(core): add UnionToIntersection type

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ npm i @utype/core
 <a href="./docs/types/nullable.md" target="_blank" ><img src="https://img.shields.io/badge/Nullable-006FEE" alt="Nullable" /></a>
 <a href="./docs/types/non-undefined.md" target="_blank" ><img src="https://img.shields.io/badge/NonUndefined-006FEE" alt="NonUndefined" /></a>
 <a href="./docs/types/omit-never.md" target="_blank" ><img src="https://img.shields.io/badge/OmitNever-006FEE" alt="OmitNever" /></a>
+<a href="./docs/types/union-to-intersection.md" target="_blank" ><img src="https://img.shields.io/badge/UnionToIntersection-006FEE" alt="UnionToIntersection" /></a>
 
 ### 🚀 Get Object Keys
 

--- a/docs/.vitepress/pages/types.json
+++ b/docs/.vitepress/pages/types.json
@@ -79,6 +79,10 @@
         "text": "OmitNever"
       },
       {
+        "link": "/union-to-intersection",
+        "text": "UnionToIntersection"
+      },
+      {
         "link": "/deep-keys",
         "text": "DeepKeys"
       },

--- a/docs/types/union-to-intersection.md
+++ b/docs/types/union-to-intersection.md
@@ -1,0 +1,24 @@
+---
+category: Generate Object
+alias: Union2Intersection UToI U2I
+---
+
+# UnionToIntersection
+
+<TypeInfo category="Generate Object" :alias="['Union2Intersection', 'UToI', 'U2I']" />
+
+Get intersection type given union type U.
+
+## Usage
+
+```ts
+import type { UnionToIntersection } from '@utype/core'
+
+type Prop = { name: string } | { age: number } | { visible: boolean }
+
+// Expect: { name: string } & { age: number } & { visible: boolean } // [!code highlight]
+type UnionToIntersectionProp = UnionToIntersection<Prop>
+
+// Expect: 'foo' & 42 & true // [!code highlight]
+type Case = UnionToIntersection<'foo' | 42 | true>
+```

--- a/packages/core/UnionToIntersection/index.d.test.ts
+++ b/packages/core/UnionToIntersection/index.d.test.ts
@@ -1,0 +1,18 @@
+import type { UnionToIntersection } from "@utype/core";
+import { Equal, Expect } from "@utype/shared";
+
+type Case = { name: string } | { age: number } | { visible: boolean };
+type UnionToIntersectionCase = { name: string } & { age: number } & {
+  visible: boolean;
+};
+
+type cases = [
+  Expect<Equal<UnionToIntersection<Case>, UnionToIntersectionCase>>,
+  Expect<Equal<UnionToIntersection<"foo" | 42 | true>, "foo" & 42 & true>>,
+  Expect<
+    Equal<
+      UnionToIntersection<(() => "foo") | ((i: 42) => true)>,
+      (() => "foo") & ((i: 42) => true)
+    >
+  >
+];

--- a/packages/core/UnionToIntersection/index.d.ts
+++ b/packages/core/UnionToIntersection/index.d.ts
@@ -1,0 +1,34 @@
+/**
+ * UnionToIntersection
+ * @description Get intersection type given union type U.
+ * @example
+ *  type Prop = { name: string } | { age: number } | { visible: boolean }
+ *  // Expect: { name: string } & { age: number } & { visible: boolean }
+ *  type UnionToIntersectionProp = UnionToIntersection<Prop>
+ *  // Expect: 'foo' & 42 & true
+ *  type Case = UnionToIntersection<'foo' | 42 | true>
+ */
+export type UnionToIntersection<U> = _UnionToUFunctions<U> extends (arg: infer I) => void ? I : never;
+
+/** @private */
+export type _UnionToUFunctions<U> = U extends any ? (arg: U) => any : never;
+
+// alias
+
+/**
+ * Union2Intersection
+ * @description Alias for UnionToIntersection
+ */
+export type Union2Intersection<U> = UnionToIntersection<U>;
+
+/**
+ * UToI
+ * @description Alias for UnionToIntersection
+ */
+export type UToI<U> = UnionToIntersection<U>;
+
+/**
+ * U2I
+ * @description Alias for UnionToIntersection
+ */
+export type U2I<U> = UnionToIntersection<U>;

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -16,6 +16,7 @@ export * from './TwoTuple'
 export * from './Nullable'
 export * from './NonUndefined'
 export * from './OmitNever'
+export * from './UnionToIntersection'
 
 export * from "./DeepKeys";
 export * from './ReadonlyKeys'


### PR DESCRIPTION
Add new Type: UnionToIntersection<U>.

It will get intersection type given union type U.

Example:

```ts
type Prop = { name: string } | { age: number } | { visible: boolean }

// Expect: { name: string } & { age: number } & { visible: boolean }
type UnionToIntersectionProp = UnionToIntersection<Prop>

// Expect: 'foo' & 42 & true
type Case = UnionToIntersection<'foo' | 42 | true>
```